### PR TITLE
Updating Atlassian connector and Jira addon to SDK v3 (take 2)

### DIFF
--- a/addons/atlassian-jira/fusebit.json
+++ b/addons/atlassian-jira/fusebit.json
@@ -1,3 +1,23 @@
 {
-  "fuseVersion": "1.8.4"
+  "security": {
+    "authentication": "optional",
+    "authorization": [
+      {
+        "action": "function:execute",
+        "resource": "/account/{{accountId}}/subscription/{{subscriptionId}}/boundary/{{boundaryId}}/functions/{{functionId}}/"
+      }
+    ],
+    "functionPermissions": {
+      "allow": [
+        {
+          "action": "storage:*",
+          "resource": "/account/{{accountId}}/subscription/{{subscriptionId}}/storage/"
+        },
+        {
+          "action": "function:*",
+          "resource": "/account/{{accountId}}/subscription/{{subscriptionId}}/"
+        }
+      ]
+    }
+  }
 }

--- a/addons/atlassian-jira/package.json
+++ b/addons/atlassian-jira/package.json
@@ -3,7 +3,7 @@
     "node": "10"
   },
   "dependencies": {
-    "@fusebit/add-on-sdk": "^2.0.0",
+    "@fusebit/add-on-sdk": "^3.0.1",
     "superagent": "^5.2.2"
   }
 }

--- a/addons/atlassian-jira/template/package.json
+++ b/addons/atlassian-jira/template/package.json
@@ -4,7 +4,7 @@
   },
   "dependencies": {
     "superagent": "^5.2.2",
-    "@fusebit/add-on-sdk": "^1.0.6",
+    "@fusebit/add-on-sdk": "^3.0.1",
     "@atlassian/jira": "^0.1.0"
   }
 }

--- a/addons/atlassian-jira/uninstall.js
+++ b/addons/atlassian-jira/uninstall.js
@@ -3,16 +3,22 @@ This is the uninstallation logic of the Lifecycle Manager.
 */
 
 const Sdk = require('@fusebit/add-on-sdk');
-const Superagent = require('superagent');
 
 module.exports = async (ctx) => {
-  let functionCtx = await Sdk.getFunctionDefinition(ctx);
+  if (!ctx.caller.permissions) {
+    return { status: 403 };
+  }
 
-  await Sdk.deleteStorage(ctx, functionCtx.configuration);
-  Sdk.debug('Storage deleted', functionCtx.location);
+  const storage = await Sdk.createStorageClient(
+    ctx.body,
+    ctx.fusebit.functionAccessToken,
+    `boundary/${ctx.body.boundaryId}/function/${ctx.body.functionId}`
+  );
+  await storage.delete();
+  Sdk.debug('Storage deleted');
 
-  await Sdk.deleteFunction(ctx);
-  Sdk.debug('Function deleted', functionCtx.location);
+  await Sdk.deleteFunction(ctx, ctx.fusebit.functionAccessToken);
+  Sdk.debug('Function deleted');
 
   return { status: 204 };
 };

--- a/connectors/atlassian/form.html
+++ b/connectors/atlassian/form.html
@@ -72,7 +72,6 @@
           const state = ##state##;
           const data = ##data##;
           const [params, setParams] = React.useState({
-              atlassian_host_url: '',
               atlassian_client_id: '',
               atlassian_client_secret: '',
               atlassian_scope: 'read:jira-user',
@@ -150,7 +149,6 @@
                       <Grid container spacing={2}>
                           <Grid item xs={12}>
                               <Grid container spacing={2}>
-                                  {getInput('atlassian_host_url', 'Atlassian Instance URL', 'Base instance URL, such as https://instance.atlassian.net')}
                                   {getInput('atlassian_client_id', 'Atlassian Client ID', 'OAuth client ID of your Atlassian App')}
                                   {getInput('atlassian_client_secret', 'Atlassian Client Secret', 'OAuth client secret of the Atlassian App')}
                                   {getInput('atlassian_scope', 'Atlassian OAuth Scopes', 'Default OAuth scopes to request, space delimited')}

--- a/connectors/atlassian/fusebit.json
+++ b/connectors/atlassian/fusebit.json
@@ -1,47 +1,23 @@
 {
-  "fuseVersion": "1.8.0",
-  "metadata": {
-    "fusebit": {
-      "runner": "// Return a function that evaluates to a Superagent request promise\n\nctx => Superagent.get(ctx.url);\n\n// Simple POST request\n// ctx => Superagent.post(ctx.url)\n//     .send({ hello: 'world' });\n\n// POST request with Authorization header using function's application settings\n// ctx => Superagent.post(ctx.url)\n//     .set('Authorization', `Bearer ${ctx.configuration.MY_API_KEY}`)\n//     .send({ hello: 'world' });\n",
-      "editor": {
-        "ensureFunctionExists": false,
-        "theme": "light",
-        "actionPanel": {
-          "theme": "light",
-          "enableCodeOnlyToggle": true,
-          "enableFullScreen": true,
-          "enableRun": true,
-          "enableSave": true,
-          "enableClose": false
-        },
-        "editorPanel": {
-          "theme": "light"
-        },
-        "logsPanel": {
-          "theme": "light",
-          "maxSize": 10240
-        },
-        "navigationPanel": {
-          "theme": "light",
-          "hideCode": false,
-          "hideFiles": [],
-          "hideComputeSettings": true,
-          "hideConfigurationSettings": false,
-          "hideScheduleSettings": false,
-          "hideRunnerTool": false
-        },
-        "statusPanel": {
-          "theme": "light"
-        },
-        "version": "1.4.0"
+  "security": {
+    "authentication": "optional",
+    "authorization": [
+      {
+        "action": "function:execute",
+        "resource": "/account/{{accountId}}/subscription/{{subscriptionId}}/boundary/{{boundaryId}}/function/{{functionId}}/"
       }
+    ],
+    "functionPermissions": {
+      "allow": [
+        {
+          "action": "storage:*",
+          "resource": "/account/{{accountId}}/subscription/{{subscriptionId}}/storage/"
+        },
+        {
+          "action": "function:*",
+          "resource": "/account/{{accountId}}/subscription/{{subscriptionId}}/"
+        }
+      ]
     }
-  },
-  "compute": {
-    "memorySize": 128,
-    "timeout": 30,
-    "staticIp": false
-  },
-  "computeSerialized": "memorySize=128\ntimeout=30\nstaticIp=false",
-  "scheduleSerialized": "# Set the 'cron' value to execute this function on a schedule\n\n# Check available timezone identifiers at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones\n# Default is UTC.\n# timezone=US/Pacific\n\n# Design a CRON schedule at https://crontab.guru/\n\n# Every day at midnight\n# cron=0 0 * * *\n\n# Every day at 5am\n# cron=0 5 * * *\n\n# Every hour\n# cron=0 */1 * * *\n\n# Every 15 minutes\n# cron=*/15 * * * *\n\n# At 10pm every Friday\n# cron=0 22 * * Fri\n"
+  }
 }

--- a/connectors/atlassian/install.js
+++ b/connectors/atlassian/install.js
@@ -7,13 +7,16 @@ const getTemplateFile = (fileName) => Fs.readFileSync(__dirname + `/template/${f
 const Sdk = require('@fusebit/add-on-sdk');
 
 module.exports = async (ctx) => {
-  // Create the Addon Handler
-  await Sdk.createFunction(ctx, {
-    configurationSerialized: `# Generate debugging information to logs
-debug=1
+  if (!ctx.caller.permissions) {
+    return { status: 403 };
+  }
 
-# Atlassian Instance URL 
-atlassian_host_url=${ctx.body.configuration.atlassian_host_url}
+  // Create the Addon Handler
+  await Sdk.createFunction(
+    ctx,
+    {
+      configurationSerialized: `# Generate debugging information to logs
+debug=1
 
 # OAuth Client ID of the Atlassian App
 atlassian_client_id=${ctx.body.configuration.atlassian_client_id}
@@ -27,33 +30,50 @@ atlassian_scope=${ctx.body.configuration.atlassian_scope || ''}
 # Allowed returnTo URLs. Comma delimited. Use wildcard (*) at the end of a URL to allow for a prefix match
 fusebit_allowed_return_to=${ctx.body.configuration.fusebit_allowed_return_to}
 `,
-    nodejs: {
-      files: {
-        'package.json': {
-          engines: {
-            node: '10',
+      nodejs: {
+        files: {
+          'package.json': {
+            engines: {
+              node: '10',
+            },
+            dependencies: {
+              superagent: '^5.2.2',
+              '@fusebit/add-on-sdk': '^3.0.1',
+            },
           },
-          dependencies: {
-            superagent: '^5.2.2',
-            '@fusebit/add-on-sdk': '^1.0.5',
-          },
-        },
-        'index.js': getTemplateFile('index.js'),
-        'initial.html': getTemplateFile('initial.html'),
-        'configure.js': getTemplateFile('configure.js'),
-      },
-    },
-    metadata: {
-      fusebit: {
-        editor: {
-          navigationPanel: {
-            hideFiles: [],
-          },
+          'index.js': getTemplateFile('index.js'),
+          'initial.html': getTemplateFile('initial.html'),
+          'configure.js': getTemplateFile('configure.js'),
         },
       },
-      ...ctx.body.metadata,
+      security: {
+        // External calls from Atlassian OAuth redirect
+        // Internal calls from addon instances triggering OAuth flow, getting tokens
+        authentication: 'optional',
+        authorization: [
+          {
+            action: 'function:execute',
+            resource:
+              '/account/{{accountId}}/subscription/{{subscriptionId}}/boundary/{{boundaryId}}/function/{{functionId}}/',
+          },
+        ],
+        functionPermissions: {
+          allow: [
+            {
+              // :post to its own storage
+              action: 'storage:*',
+              resource:
+                '/account/{{accountId}}/subscription/{{subscriptionId}}/storage/boundary/{{boundaryId}}/function/{{functionId}}/',
+            },
+          ],
+        },
+      },
+      metadata: {
+        ...ctx.body.metadata,
+      },
     },
-  });
+    ctx.fusebit.functionAccessToken
+  );
 
   return { status: 200, body: { status: 200 } };
 };

--- a/connectors/atlassian/package.json
+++ b/connectors/atlassian/package.json
@@ -4,6 +4,6 @@
   },
   "dependencies": {
     "superagent": "^5.2.2",
-    "@fusebit/add-on-sdk": "^1.0.6"
+    "@fusebit/add-on-sdk": "^3.0.1"
   }
 }

--- a/connectors/atlassian/template/configure.js
+++ b/connectors/atlassian/template/configure.js
@@ -73,6 +73,7 @@ module.exports = {
           ...state.data,
           atlassian_refresh_token: response.body.refresh_token,
           atlassian_get_token_url: `${selfUrl}/token`,
+          atlassian_resource_path: `/account/${ctx.accountId}/subscription/${ctx.subscriptionId}/boundary/${ctx.boundaryId}/function/${ctx.functionId}/`,
         };
         return Sdk.completeWithSuccess(state, data);
       } else {

--- a/connectors/atlassian/template/index.js
+++ b/connectors/atlassian/template/index.js
@@ -35,7 +35,7 @@ const getAccessToken = async (ctx) => {
     })
     .then((res) => (response = res));
 
-  return response.body.access_token;
+  return response.body;
 };
 
 /**
@@ -43,8 +43,12 @@ const getAccessToken = async (ctx) => {
  */
 module.exports = async (ctx) => {
   if (ctx.body.refresh_token) {
+    if (!ctx.caller.permissions) {
+      return { status: 403 };
+    }
+
     // Request for access token
-    return { body: { accessToken: await getAccessToken(ctx) } };
+    return { body: await getAccessToken(ctx) };
   }
 
   return settingsManager(ctx);

--- a/connectors/atlassian/uninstall.js
+++ b/connectors/atlassian/uninstall.js
@@ -5,8 +5,12 @@ This is the uninstallation logic of the Lifecycle Manager.
 const Sdk = require('@fusebit/add-on-sdk');
 
 module.exports = async (ctx) => {
-  // Destroy the Add-On Handler
-  await Sdk.deleteFunction(ctx);
+  if (!ctx.caller.permissions) {
+    return { status: 403 };
+  }
+
+  await Sdk.deleteFunction(ctx, ctx.fusebit.functionAccessToken);
+  Sdk.debug('Function deleted');
 
   return { status: 204 };
 };


### PR DESCRIPTION
(original accidentally-closed PR here #10)

Additional fixes made:
- The connector was collecting an Atlassian domain/host name property that was unused and misleading, removed
- Upgraded the logic in the addon to cache the access token and its expiration, instead of getting a new one on every request